### PR TITLE
feat: Add native Claude CLI session storage support

### DIFF
--- a/Sources/ClaudeCodeSDK/Storage/ClaudeNativeSessionStorage.swift
+++ b/Sources/ClaudeCodeSDK/Storage/ClaudeNativeSessionStorage.swift
@@ -1,0 +1,238 @@
+//
+//  ClaudeNativeSessionStorage.swift
+//  ClaudeCodeSDK
+//
+//  Created by Assistant on 8/18/2025.
+//
+
+import Foundation
+import OSLog
+
+/// Implementation of Claude's native session storage that reads from ~/.claude/projects/
+public class ClaudeNativeSessionStorage: ClaudeSessionStorageProtocol {
+  private let basePath: String
+  private let fileManager = FileManager.default
+  private let logger = Logger(subsystem: "com.claudecode.sdk", category: "SessionStorage")
+  private let decoder = JSONDecoder()
+  
+  public init(basePath: String? = nil) {
+    self.basePath = basePath ?? NSString(string: "~/.claude/projects").expandingTildeInPath
+  }
+  
+  // MARK: - Public Methods
+  
+  public func listProjects() async throws -> [String] {
+    guard fileManager.fileExists(atPath: basePath) else {
+      logger.info("Claude projects directory not found at \(self.basePath)")
+      return []
+    }
+    
+    let contents = try fileManager.contentsOfDirectory(atPath: basePath)
+    
+    // Filter only directories and decode the project paths
+    let projects = contents.compactMap { item -> String? in
+      let fullPath = (basePath as NSString).appendingPathComponent(item)
+      var isDirectory: ObjCBool = false
+      
+      guard fileManager.fileExists(atPath: fullPath, isDirectory: &isDirectory),
+            isDirectory.boolValue else {
+        return nil
+      }
+      
+      // Decode the project path (convert dashes back to slashes)
+      return decodeProjectPath(item)
+    }
+    
+    return projects.sorted()
+  }
+  
+  public func getSessions(for projectPath: String) async throws -> [ClaudeStoredSession] {
+    let encodedPath = encodeProjectPath(projectPath)
+    let projectDir = (basePath as NSString).appendingPathComponent(encodedPath)
+    
+    guard fileManager.fileExists(atPath: projectDir) else {
+      logger.info("No sessions found for project: \(projectPath)")
+      return []
+    }
+    
+    let files = try fileManager.contentsOfDirectory(atPath: projectDir)
+    let jsonlFiles = files.filter { $0.hasSuffix(".jsonl") }
+    
+    var sessions: [ClaudeStoredSession] = []
+    
+    for file in jsonlFiles {
+      let sessionId = String(file.dropLast(6)) // Remove .jsonl extension
+      let filePath = (projectDir as NSString).appendingPathComponent(file)
+      
+      if let session = try await parseSessionFile(
+        at: filePath,
+        sessionId: sessionId,
+        projectPath: projectPath
+      ) {
+        sessions.append(session)
+      }
+    }
+    
+    // Sort by last accessed date (most recent first)
+    return sessions.sorted { $0.lastAccessedAt > $1.lastAccessedAt }
+  }
+  
+  public func getSession(id: String, projectPath: String) async throws -> ClaudeStoredSession? {
+    let encodedPath = encodeProjectPath(projectPath)
+    let projectDir = (basePath as NSString).appendingPathComponent(encodedPath)
+    let filePath = (projectDir as NSString).appendingPathComponent("\(id).jsonl")
+    
+    guard fileManager.fileExists(atPath: filePath) else {
+      logger.info("Session file not found: \(filePath)")
+      return nil
+    }
+    
+    return try await parseSessionFile(
+      at: filePath,
+      sessionId: id,
+      projectPath: projectPath
+    )
+  }
+  
+  public func getAllSessions() async throws -> [ClaudeStoredSession] {
+    let projects = try await listProjects()
+    var allSessions: [ClaudeStoredSession] = []
+    
+    for project in projects {
+      let sessions = try await getSessions(for: project)
+      allSessions.append(contentsOf: sessions)
+    }
+    
+    // Sort all sessions by last accessed date
+    return allSessions.sorted { $0.lastAccessedAt > $1.lastAccessedAt }
+  }
+  
+  public func getMessages(sessionId: String, projectPath: String) async throws -> [ClaudeStoredMessage] {
+    if let session = try await getSession(id: sessionId, projectPath: projectPath) {
+      return session.messages
+    }
+    return []
+  }
+  
+  public func getMostRecentSession(for projectPath: String) async throws -> ClaudeStoredSession? {
+    let sessions = try await getSessions(for: projectPath)
+    return sessions.first // Already sorted by most recent
+  }
+  
+  // MARK: - Private Methods
+  
+  private func encodeProjectPath(_ path: String) -> String {
+    // Replace slashes with dashes, as Claude CLI does
+    return path.replacingOccurrences(of: "/", with: "-")
+  }
+  
+  private func decodeProjectPath(_ encoded: String) -> String {
+    // Convert dashes back to slashes
+    return encoded.replacingOccurrences(of: "-", with: "/")
+  }
+  
+  private func parseSessionFile(
+    at filePath: String,
+    sessionId: String,
+    projectPath: String
+  ) async throws -> ClaudeStoredSession? {
+    guard let data = fileManager.contents(atPath: filePath) else {
+      logger.error("Failed to read session file: \(filePath)")
+      return nil
+    }
+    
+    // Parse JSONL file (each line is a separate JSON object)
+    let lines = String(data: data, encoding: .utf8)?.components(separatedBy: .newlines) ?? []
+    
+    var messages: [ClaudeStoredMessage] = []
+    var summary: String?
+    var gitBranch: String?
+    var firstTimestamp: Date?
+    var lastTimestamp: Date?
+    
+    for line in lines where !line.isEmpty {
+      guard let lineData = line.data(using: .utf8) else { continue }
+      
+      do {
+        let entry = try decoder.decode(ClaudeJSONLEntry.self, from: lineData)
+        
+        // Extract summary if present
+        if entry.type == "summary", let entrySummary = entry.summary {
+          summary = entrySummary
+        }
+        
+        // Extract git branch from first user message
+        if gitBranch == nil, entry.type == "user" {
+          gitBranch = entry.gitBranch
+        }
+        
+        // Parse messages
+        if let message = entry.message,
+           let role = message.role,
+           let uuid = entry.uuid {
+          
+          let timestamp = parseTimestamp(entry.timestamp)
+          
+          // Track first and last timestamps
+          if let ts = timestamp {
+            if firstTimestamp == nil || ts < firstTimestamp! {
+              firstTimestamp = ts
+            }
+            if lastTimestamp == nil || ts > lastTimestamp! {
+              lastTimestamp = ts
+            }
+          }
+          
+          // Extract text content
+          let content = message.content?.textContent ?? ""
+          
+          let storedMessage = ClaudeStoredMessage(
+            id: uuid,
+            parentId: entry.parentUuid,
+            sessionId: entry.sessionId ?? sessionId,
+            role: ClaudeStoredMessage.MessageRole(rawValue: role) ?? .user,
+            content: content,
+            timestamp: timestamp ?? Date(),
+            cwd: entry.cwd,
+            version: entry.version
+          )
+          
+          messages.append(storedMessage)
+        }
+      } catch {
+        // Log but continue parsing other lines
+        logger.debug("Failed to parse JSONL line: \(error)")
+      }
+    }
+    
+    // If we found any messages, create a session
+    guard !messages.isEmpty || summary != nil else {
+      return nil
+    }
+    
+    return ClaudeStoredSession(
+      id: sessionId,
+      projectPath: projectPath,
+      createdAt: firstTimestamp ?? Date(),
+      lastAccessedAt: lastTimestamp ?? Date(),
+      summary: summary,
+      gitBranch: gitBranch,
+      messages: messages
+    )
+  }
+  
+  private func parseTimestamp(_ timestamp: String?) -> Date? {
+    guard let timestamp = timestamp else { return nil }
+    
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    
+    if let date = formatter.date(from: timestamp) {
+      return date
+    }
+    
+    // Try without fractional seconds
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter.date(from: timestamp)
+  }
+}

--- a/Sources/ClaudeCodeSDK/Storage/ClaudeSessionModels.swift
+++ b/Sources/ClaudeCodeSDK/Storage/ClaudeSessionModels.swift
@@ -1,0 +1,179 @@
+//
+//  ClaudeSessionModels.swift
+//  ClaudeCodeSDK
+//
+//  Created by Assistant on 8/18/2025.
+//
+
+import Foundation
+
+/// Represents a stored Claude session from the native CLI storage
+public struct ClaudeStoredSession: Identifiable, Codable {
+  public let id: String
+  public let projectPath: String
+  public let createdAt: Date
+  public let lastAccessedAt: Date
+  public var summary: String?
+  public var gitBranch: String?
+  public var messages: [ClaudeStoredMessage]
+  
+  public init(
+    id: String,
+    projectPath: String,
+    createdAt: Date = Date(),
+    lastAccessedAt: Date = Date(),
+    summary: String? = nil,
+    gitBranch: String? = nil,
+    messages: [ClaudeStoredMessage] = []
+  ) {
+    self.id = id
+    self.projectPath = projectPath
+    self.createdAt = createdAt
+    self.lastAccessedAt = lastAccessedAt
+    self.summary = summary
+    self.gitBranch = gitBranch
+    self.messages = messages
+  }
+}
+
+/// Represents a message in a Claude session
+public struct ClaudeStoredMessage: Identifiable, Codable {
+  public let id: String // UUID from the jsonl file
+  public let parentId: String?
+  public let sessionId: String
+  public let role: MessageRole
+  public let content: String
+  public let timestamp: Date
+  public let cwd: String?
+  public let version: String?
+  
+  public enum MessageRole: String, Codable {
+    case user
+    case assistant
+    case system
+  }
+  
+  public init(
+    id: String,
+    parentId: String? = nil,
+    sessionId: String,
+    role: MessageRole,
+    content: String,
+    timestamp: Date,
+    cwd: String? = nil,
+    version: String? = nil
+  ) {
+    self.id = id
+    self.parentId = parentId
+    self.sessionId = sessionId
+    self.role = role
+    self.content = content
+    self.timestamp = timestamp
+    self.cwd = cwd
+    self.version = version
+  }
+}
+
+/// Raw JSON structure from Claude's .jsonl files
+internal struct ClaudeJSONLEntry: Codable {
+  let type: String
+  let uuid: String?
+  let parentUuid: String?
+  let sessionId: String?
+  let timestamp: String?
+  let cwd: String?
+  let version: String?
+  let gitBranch: String?
+  let message: MessageContent?
+  let summary: String?
+  let leafUuid: String?
+  let requestId: String?
+  
+  struct MessageContent: Codable {
+    let role: String?
+    let content: MessageContentValue?
+  }
+  
+  enum MessageContentValue: Codable {
+    case string(String)
+    case array([ContentItem])
+    
+    init(from decoder: Decoder) throws {
+      let container = try decoder.singleValueContainer()
+      if let stringValue = try? container.decode(String.self) {
+        self = .string(stringValue)
+      } else if let arrayValue = try? container.decode([ContentItem].self) {
+        self = .array(arrayValue)
+      } else {
+        throw DecodingError.typeMismatch(
+          MessageContentValue.self,
+          DecodingError.Context(
+            codingPath: decoder.codingPath,
+            debugDescription: "Expected String or [ContentItem]"
+          )
+        )
+      }
+    }
+    
+    func encode(to encoder: Encoder) throws {
+      var container = encoder.singleValueContainer()
+      switch self {
+      case .string(let value):
+        try container.encode(value)
+      case .array(let items):
+        try container.encode(items)
+      }
+    }
+    
+    var textContent: String {
+      switch self {
+      case .string(let str):
+        return str
+      case .array(let items):
+        return items.compactMap { item in
+          if case .text(let text) = item.type {
+            return text
+          }
+          return nil
+        }.joined(separator: "\n")
+      }
+    }
+  }
+  
+  struct ContentItem: Codable {
+    let type: ContentType
+    
+    enum ContentType: Codable {
+      case text(String)
+      case other
+      
+      init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let typeString = try container.decode(String.self, forKey: .type)
+        
+        if typeString == "text" {
+          let text = try container.decode(String.self, forKey: .text)
+          self = .text(text)
+        } else {
+          self = .other
+        }
+      }
+      
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .text(let text):
+          try container.encode("text", forKey: .type)
+          try container.encode(text, forKey: .text)
+        case .other:
+          try container.encode("other", forKey: .type)
+        }
+      }
+      
+      enum CodingKeys: String, CodingKey {
+        case type
+        case text
+      }
+    }
+  }
+}

--- a/Sources/ClaudeCodeSDK/Storage/ClaudeSessionProtocol.swift
+++ b/Sources/ClaudeCodeSDK/Storage/ClaudeSessionProtocol.swift
@@ -1,0 +1,29 @@
+//
+//  ClaudeSessionProtocol.swift
+//  ClaudeCodeSDK
+//
+//  Created by Assistant on 8/18/2025.
+//
+
+import Foundation
+
+/// Protocol for accessing Claude's native session storage
+public protocol ClaudeSessionStorageProtocol {
+  /// Lists all projects that have sessions
+  func listProjects() async throws -> [String]
+  
+  /// Gets all sessions for a specific project
+  func getSessions(for projectPath: String) async throws -> [ClaudeStoredSession]
+  
+  /// Gets a specific session by ID
+  func getSession(id: String, projectPath: String) async throws -> ClaudeStoredSession?
+  
+  /// Gets all sessions across all projects
+  func getAllSessions() async throws -> [ClaudeStoredSession]
+  
+  /// Gets the messages for a specific session
+  func getMessages(sessionId: String, projectPath: String) async throws -> [ClaudeStoredMessage]
+  
+  /// Gets the most recent session for a project
+  func getMostRecentSession(for projectPath: String) async throws -> ClaudeStoredSession?
+}


### PR DESCRIPTION
## Summary

This PR adds support for reading Claude CLI's native session storage directly from `~/.claude/projects/`, providing complete synchronization between CLI and SDK usage.

## Changes

- ✨ Added `ClaudeNativeSessionStorage` class for accessing native session files
- 📦 Added data models for `ClaudeStoredSession` and `ClaudeStoredMessage`
- 🔧 Added `ClaudeSessionStorageProtocol` for storage abstraction
- 📄 Updated README with comprehensive documentation and examples
- 🧹 Removed temporary test scripts

## Features

- **Direct access to CLI sessions**: Read sessions created from Claude CLI
- **Project-based organization**: Sessions automatically organized by project path
- **Rich metadata**: Access git branch, working directory, timestamps
- **Full conversation history**: Access all messages with parent-child relationships
- **JSONL parsing**: Complete parsing of Claude's native storage format

## Benefits

- 🔄 **Complete sync** between CLI and SDK sessions
- 📁 **Single source of truth** for all Claude conversations
- 🚫 **No duplication** of session storage
- 📊 **Rich session data** including summaries and metadata

## Usage Example

```swift
let storage = ClaudeNativeSessionStorage()

// Get sessions for a project
let sessions = try await storage.getSessions(for: "/path/to/project")

// Access the most recent session
if let recent = try await storage.getMostRecentSession(for: "/path/to/project") {
    print("Session: \(recent.id)")
    print("Messages: \(recent.messages.count)")
}
```

## Testing

The implementation has been tested with real Claude CLI session files and correctly parses:
- Session metadata (ID, timestamps, git branch)
- Message content with proper role attribution
- Parent-child message relationships
- Summary information when available

🤖 Generated with [Claude Code](https://claude.ai/code)