### PR TITLE
feat: Add disallowedTools property to ClaudeCodeConfiguration

### DIFF
--- a/Sources/ClaudeCodeSDK/API/ClaudeCodeConfiguration.swift
+++ b/Sources/ClaudeCodeSDK/API/ClaudeCodeConfiguration.swift
@@ -26,6 +26,9 @@ public struct ClaudeCodeConfiguration {
   
   /// Optional suffix to append after the command (e.g., "--" for "airchat --")
   public var commandSuffix: String?
+
+  /// List of tools that should be disallowed for Claude to use
+  public var disallowedTools: [String]?
   
   /// Default configuration
   public static var `default`: ClaudeCodeConfiguration {
@@ -42,7 +45,8 @@ public struct ClaudeCodeConfiguration {
         "/usr/sbin",          // System administration binaries
         "/sbin"               // Essential system binaries
       ],
-      commandSuffix: nil
+      commandSuffix: nil,
+      disallowedTools: nil
     )
   }
   
@@ -59,7 +63,8 @@ public struct ClaudeCodeConfiguration {
       "/usr/sbin",          // System administration binaries
       "/sbin"               // Essential system binaries
     ],
-    commandSuffix: String? = nil
+    commandSuffix: String? = nil,
+    disallowedTools: [String]? = nil
   ) {
     self.command = command
     self.workingDirectory = workingDirectory
@@ -67,5 +72,6 @@ public struct ClaudeCodeConfiguration {
     self.enableDebugLogging = enableDebugLogging
     self.additionalPaths = additionalPaths
     self.commandSuffix = commandSuffix
+    self.disallowedTools = disallowedTools
   }
 }


### PR DESCRIPTION
## Summary
- Added `disallowedTools` property to `ClaudeCodeConfiguration` to enable SDK consumers to specify which tools should be restricted
- This brings configuration parity with the existing `ClaudeCodeOptions` which already supports disallowedTools
- Maintains backward compatibility with default value of `nil`

## Changes
- Added `public var disallowedTools: [String]?` property to ClaudeCodeConfiguration
- Updated default configuration to include `disallowedTools: nil`
- Updated initializer to accept `disallowedTools` parameter with default value `nil`
- Added property assignment in initializer

## Test Plan
- [x] Swift build succeeds without errors
- [x] Existing tests continue to pass
- [x] ClaudeCodeOptions already has test coverage for disallowedTools functionality

🤖 Generated with [Claude Code](https://claude.ai/code)