### PR TITLE
docs: Clarify that iOS is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ClaudeCodeSDK
 
-[Beta] A Swift SDK for seamlessly integrating Claude Code into your iOS and macOS applications. Interact with Anthropic's Claude Code programmatically for AI-powered coding assistance.
+[Beta] A Swift SDK for seamlessly integrating Claude Code into your macOS applications. Interact with Anthropic's Claude Code programmatically for AI-powered coding assistance.
 
 ## ✨ What's New
 
@@ -18,9 +18,11 @@ ClaudeCodeSDK allows you to integrate Claude Code's capabilities directly into y
 
 ## Requirements
 
-* **Platforms:** iOS 15+ or macOS 13+
+* **Platforms:** macOS 13+
 * **Swift Version:** Swift 6.0+
 * **Dependencies:** Claude Code CLI installed (`npm install -g @anthropic/claude-code`)
+
+> **Note:** iOS is not supported because the SDK relies on spawning the Claude CLI as a subprocess using the `Process` API, which is only available on macOS. iOS apps run in a sandboxed environment that prevents executing external processes.
 
 ## 🚀 Installation
 


### PR DESCRIPTION
## Summary
- Updated README to clarify that the SDK only supports macOS, not iOS
- Added explanatory note about why iOS cannot be supported

## Context
A user raised a question about iOS support mentioned in the README. While the Package.swift includes iOS as a platform (allowing the SDK to compile for iOS), the SDK cannot actually function on iOS devices.

## Why iOS Cannot Be Supported
1. **Process API limitation**: The SDK uses the `Process` class to spawn the Claude CLI, which is only available on macOS
2. **iOS sandboxing**: iOS apps run in a sandboxed environment that prevents executing external processes
3. **CLI installation**: The Claude CLI (`npm install -g @anthropic/claude-code`) cannot be installed on iOS devices

## Changes
- Removed "iOS and" from the main description
- Changed platform requirement from "iOS 15+ or macOS 13+" to "macOS 13+"
- Added a clear note explaining why iOS is not supported

This prevents confusion for users who might try to use the SDK on iOS and wonder why it doesn't work.

🤖 Generated with [Claude Code](https://claude.ai/code)