### PR TITLE
feat: Add lastExecutedCommandInfo property for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,79 @@ if let nvmPath = NvmPathDetector.detectNvmPath() {
 let config = ClaudeCodeConfiguration.withNvmSupport()
 ```
 
+## Debugging
+
+The SDK provides access to the last executed command for debugging and troubleshooting purposes.
+
+### Accessing Command Information
+
+After executing any command, you can access detailed information about it:
+
+```swift
+let client = ClaudeCodeClient()
+
+let result = try await client.runSinglePrompt(
+  prompt: "Write a function",
+  outputFormat: .streamJson,
+  options: options
+)
+
+// Access the last executed command information
+if let commandInfo = client.lastExecutedCommandInfo {
+  print("Command: \(commandInfo.commandString)")
+  print("Working Directory: \(commandInfo.workingDirectory ?? "None")")
+  print("Stdin Content: \(commandInfo.stdinContent ?? "None")")
+  print("Executed At: \(commandInfo.executedAt)")
+  print("Method: \(commandInfo.method.rawValue)")
+}
+```
+
+### Reproducing Commands in Terminal
+
+You can use this information to reproduce the exact command in Terminal for debugging:
+
+```swift
+if let commandInfo = client.lastExecutedCommandInfo {
+  var terminalCommand = ""
+
+  // Add working directory if present
+  if let workingDir = commandInfo.workingDirectory {
+    terminalCommand += "cd \"\(workingDir)\" && "
+  }
+
+  // Add stdin if present
+  if let stdin = commandInfo.stdinContent {
+    terminalCommand += "echo \"\(stdin)\" | "
+  }
+
+  // Add the command
+  terminalCommand += commandInfo.commandString
+
+  print("Run this in Terminal:")
+  print(terminalCommand)
+
+  // Copy to clipboard if needed
+  NSPasteboard.general.clearContents()
+  NSPasteboard.general.setString(terminalCommand, forType: .string)
+}
+```
+
+### ExecutedCommandInfo Properties
+
+- **commandString**: The full command with all flags (e.g., `"claude -p --verbose --output-format stream-json"`)
+- **workingDirectory**: The directory where the command was executed
+- **stdinContent**: The content sent to stdin (user message, prompt, etc.)
+- **executedAt**: Timestamp of when the command was executed
+- **method**: The SDK method that executed the command (runSinglePrompt, continueConversation, etc.)
+
+### Use Cases
+
+- **Bug Reports**: Include exact command details in bug reports
+- **Terminal Reproduction**: Copy-paste commands to Terminal for debugging
+- **Support Tickets**: Provide exact command information to support teams
+- **Command Verification**: Verify that commands are constructed correctly
+- **Debugging Failures**: Understand what command failed and why
+
 ## License
 
 ClaudeCodeSDK is available under the MIT license. See the `LICENSE` file for more info.

--- a/Sources/ClaudeCodeSDK/API/ClaudeCode.swift
+++ b/Sources/ClaudeCodeSDK/API/ClaudeCode.swift
@@ -77,4 +77,8 @@ public protocol ClaudeCode {
   /// - Parameter command: The command to check (e.g., "npm", "node")
   /// - Returns: true if the command is found in PATH, false otherwise
   func validateCommand(_ command: String) async throws -> Bool
+
+  /// Debug information about the last command executed
+  /// Returns nil if no command has been executed yet
+  var lastExecutedCommandInfo: ExecutedCommandInfo? { get }
 }

--- a/Sources/ClaudeCodeSDK/API/ExecutedCommandInfo.swift
+++ b/Sources/ClaudeCodeSDK/API/ExecutedCommandInfo.swift
@@ -1,0 +1,36 @@
+//
+//  ExecutedCommandInfo.swift
+//  ClaudeCodeSDK
+//
+//  Created by James Rochabrun on 5/20/25.
+//
+
+import Foundation
+
+/// Information about an executed command for debugging purposes
+public struct ExecutedCommandInfo: Sendable {
+  /// The full command string with all flags (as passed to Process)
+  /// Example: "claude -p --verbose --allowedTools \"Read,Write\" --output-format stream-json"
+  public let commandString: String
+
+  /// The working directory where the command was executed
+  public let workingDirectory: String?
+
+  /// The content sent to stdin (user message, typically)
+  public let stdinContent: String?
+
+  /// When the command was executed
+  public let executedAt: Date
+
+  /// The method that executed the command
+  public let method: ExecutionMethod
+
+  /// The type of method that executed a Claude Code command
+  public enum ExecutionMethod: String, Sendable {
+    case runSinglePrompt
+    case continueConversation
+    case resumeConversation
+    case runWithStdin
+    case listSessions
+  }
+}

--- a/Sources/ClaudeCodeSDK/Utilities/RateLimiter.swift
+++ b/Sources/ClaudeCodeSDK/Utilities/RateLimiter.swift
@@ -144,7 +144,11 @@ public class RateLimitedClaudeCode: ClaudeCode {
     get { wrapped.configuration }
     set { wrapped.configuration = newValue }
   }
-  
+
+  public var lastExecutedCommandInfo: ExecutedCommandInfo? {
+    wrapped.lastExecutedCommandInfo
+  }
+
   public init(
     wrapped: ClaudeCode,
     requestsPerMinute: Int,


### PR DESCRIPTION
## Summary

Adds programmatic access to the last executed command information, enabling users to debug issues, reproduce commands in Terminal, and include detailed command info in bug reports.

This addresses the feature request to expose last executed command information for debugging purposes.

## Changes

- ✨ Add `ExecutedCommandInfo` struct with comprehensive command details:
  - Full command string with all flags
  - Working directory
  - Stdin content (no truncation)
  - Timestamp of execution
  - Execution method type
  
- ✨ Add `lastExecutedCommandInfo` property to `ClaudeCode` protocol
- ✨ Implement command info capture in `ClaudeCodeClient` for all execution methods
- ✨ Add property delegation in `RateLimitedClaudeCode` wrapper
- 📖 Add comprehensive "Debugging" section to README with examples

## Use Cases

- **Bug Reports**: Include exact command details in bug reports
- **Terminal Reproduction**: Copy-paste commands to Terminal for debugging
- **Support Tickets**: Provide exact command information to support teams
- **Command Verification**: Verify that commands are constructed correctly
- **Debugging Failures**: Understand what command failed and why

## Example Usage

\`\`\`swift
let client = ClaudeCodeClient()

let result = try await client.runSinglePrompt(
  prompt: "Write a function",
  outputFormat: .streamJson,
  options: options
)

// Access the last executed command information
if let commandInfo = client.lastExecutedCommandInfo {
  print("Command: \(commandInfo.commandString)")
  print("Working Directory: \(commandInfo.workingDirectory ?? "None")")
  print("Stdin Content: \(commandInfo.stdinContent ?? "None")")
  print("Executed At: \(commandInfo.executedAt)")
  print("Method: \(commandInfo.method.rawValue)")
}
\`\`\`

## Test Plan

- [x] Build passes successfully
- [x] All execution methods capture command info
- [x] RateLimitedClaudeCode wrapper delegates property correctly
- [x] README documentation added with examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)