### PR TITLE
Fix: Add proper shell escaping for system prompts to prevent parse er…

### DIFF
--- a/Sources/ClaudeCodeSDK/API/ClaudeCodeOptions.swift
+++ b/Sources/ClaudeCodeSDK/API/ClaudeCodeOptions.swift
@@ -68,7 +68,17 @@ public struct ClaudeCodeOptions {
   public init() {
     // Default initialization
   }
-  
+
+  /// Properly escapes a string for safe shell usage
+  /// Uses single quotes which protect against most special characters
+  /// Single quotes inside the string are escaped as '\''
+  private func shellEscape(_ string: String) -> String {
+    // Replace single quotes with '\'' (end quote, escaped quote, start quote)
+    let escaped = string.replacingOccurrences(of: "'", with: "'\\''")
+    // Wrap in single quotes
+    return "'\(escaped)'"
+  }
+
   /// Convert options to command line arguments
   internal func toCommandArgs() -> [String] {
     var args: [String] = []
@@ -113,12 +123,12 @@ public struct ClaudeCodeOptions {
     
     if let systemPrompt = systemPrompt {
       args.append("--system-prompt")
-      args.append("\"\(systemPrompt)\"")
+      args.append(shellEscape(systemPrompt))
     }
-    
+
     if let appendSystemPrompt = appendSystemPrompt {
       args.append("--append-system-prompt")
-      args.append("\"\(appendSystemPrompt)\"")
+      args.append(shellEscape(appendSystemPrompt))
     }
     
     if let permissionMode = permissionMode {

--- a/Tests/ClaudeCodeSDKTests/ShellEscapingTests.swift
+++ b/Tests/ClaudeCodeSDKTests/ShellEscapingTests.swift
@@ -1,0 +1,107 @@
+//
+//  ShellEscapingTests.swift
+//  ClaudeCodeSDK
+//
+//  Created by Assistant on 10/15/25.
+//
+
+import XCTest
+@testable import ClaudeCodeSDK
+
+final class ShellEscapingTests: XCTestCase {
+
+  func testBasicShellEscaping() {
+    let options = ClaudeCodeOptions()
+
+    // Create a test with problematic characters
+    var testOptions = options
+    testOptions.appendSystemPrompt = "Hello { world }"
+
+    let args = testOptions.toCommandArgs()
+
+    // The args should contain the --append-system-prompt flag
+    XCTAssertTrue(args.contains("--append-system-prompt"))
+
+    // Find the index of the flag
+    if let index = args.firstIndex(of: "--append-system-prompt") {
+      // The next element should be the escaped value
+      let escapedValue = args[index + 1]
+
+      // Should be wrapped in single quotes
+      XCTAssertTrue(escapedValue.hasPrefix("'"))
+      XCTAssertTrue(escapedValue.hasSuffix("'"))
+
+      print("Escaped value: \(escapedValue)")
+    }
+  }
+
+  func testShellEscapingWithNewlines() {
+    let options = ClaudeCodeOptions()
+
+    var testOptions = options
+    testOptions.appendSystemPrompt = """
+    First line
+    Second line with {braces}
+    Third line
+    """
+
+    let args = testOptions.toCommandArgs()
+
+    // Should still work with newlines
+    XCTAssertTrue(args.contains("--append-system-prompt"))
+
+    if let index = args.firstIndex(of: "--append-system-prompt") {
+      let escapedValue = args[index + 1]
+
+      // Should be properly wrapped
+      XCTAssertTrue(escapedValue.hasPrefix("'"))
+      XCTAssertTrue(escapedValue.hasSuffix("'"))
+
+      print("Escaped value with newlines: \(escapedValue)")
+    }
+  }
+
+  func testShellEscapingWithSingleQuotes() {
+    let options = ClaudeCodeOptions()
+
+    var testOptions = options
+    testOptions.appendSystemPrompt = "It's a test with 'quotes'"
+
+    let args = testOptions.toCommandArgs()
+
+    XCTAssertTrue(args.contains("--append-system-prompt"))
+
+    if let index = args.firstIndex(of: "--append-system-prompt") {
+      let escapedValue = args[index + 1]
+
+      // Should handle single quotes correctly
+      XCTAssertTrue(escapedValue.contains("'\\''"))
+
+      print("Escaped value with single quotes: \(escapedValue)")
+    }
+  }
+
+  func testShellEscapingWithComplexJSON() {
+    let options = ClaudeCodeOptions()
+
+    var testOptions = options
+    testOptions.appendSystemPrompt = """
+    {"type":"result","data":{"value":123}}
+    With unmatched { character
+    """
+
+    let args = testOptions.toCommandArgs()
+
+    XCTAssertTrue(args.contains("--append-system-prompt"))
+
+    if let index = args.firstIndex(of: "--append-system-prompt") {
+      let escapedValue = args[index + 1]
+
+      // Should be properly escaped
+      XCTAssertTrue(escapedValue.hasPrefix("'"))
+      XCTAssertTrue(escapedValue.hasSuffix("'"))
+
+      print("Escaped value with JSON: \(escapedValue)")
+    }
+  }
+}


### PR DESCRIPTION
…rors

- Add shellEscape() helper function that uses single quotes for safe escaping
- Apply proper escaping to --system-prompt and --append-system-prompt arguments
- Prevents shell parse errors when content contains special characters like:
  - Unmatched braces { }
  - Newlines
  - Quotes
  - JSON data
- Add comprehensive tests for shell escaping with various edge cases